### PR TITLE
Potential fix for code scanning alert no. 73: Incomplete regular expression for hostnames

### DIFF
--- a/wizardscupboard/wizardscupboard.go
+++ b/wizardscupboard/wizardscupboard.go
@@ -57,8 +57,8 @@ func (wc *Wizardscupboard) scrape() error {
 		colly.CacheDir(fmt.Sprintf(".cache/%d", time.Now().YearDay())),
 
 		colly.URLFilters(
-			regexp.MustCompile(`https://www\.wizardscupboard\.com/singles-.+`),
-			regexp.MustCompile(`https://www\.wizardscupboard\.com/foils-.+`),
+			regexp.MustCompile(`^https://www\.wizardscupboard\.com/singles-.+`),
+			regexp.MustCompile(`^https://www\.wizardscupboard\.com/foils-.+`),
 		),
 
 		colly.Async(true),

--- a/wizardscupboard/wizardscupboard.go
+++ b/wizardscupboard/wizardscupboard.go
@@ -57,8 +57,8 @@ func (wc *Wizardscupboard) scrape() error {
 		colly.CacheDir(fmt.Sprintf(".cache/%d", time.Now().YearDay())),
 
 		colly.URLFilters(
-			regexp.MustCompile(`https://www.wizardscupboard.com/singles-.+`),
-			regexp.MustCompile(`https://www.wizardscupboard.com/foils-.+`),
+			regexp.MustCompile(`https://www\.wizardscupboard\.com/singles-.+`),
+			regexp.MustCompile(`https://www\.wizardscupboard\.com/foils-.+`),
 		),
 
 		colly.Async(true),


### PR DESCRIPTION
Potential fix for [https://github.com/mtgban/go-mtgban/security/code-scanning/73](https://github.com/mtgban/go-mtgban/security/code-scanning/73)

To fix the error, escape all period (`.`) characters in the regular expressions specifying hostnames so that they match literal dots rather than any character. In Go, within double-quoted regex strings, you escape a dot as `\\.`; within a raw string literal (backquotes), a single escape is sufficient (`\.`). To stay consistent and minimize escaping, use a raw string literal. Apply this fix to both `regexp.MustCompile(`https://www.wizardscupboard.com/singles-.+`)` (on line 60) and `regexp.MustCompile(`https://www.wizardscupboard.com/foils-.+`)` (on line 61), escaping the dots in the host and `.+` as necessary (the trailing dash-minus and `.+` are fine). You only need to change the regular expressions by escaping the dots in `www.wizardscupboard.com`.

No other changes, methods, or imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
