### PR TITLE
sealedev: fix Direct estimate/error bugs, precompute prices, skip fixed-product sims

### DIFF
--- a/sealedev/api.go
+++ b/sealedev/api.go
@@ -167,59 +167,52 @@ func loadPrices(ctx context.Context, sig, selected string) (*BANPriceResponse, e
 		return nil, errors.New(response.Error)
 	}
 
-	// Remove outliers from Direct
+	// Adjust Direct/CT0 estimates and prune bulk in a single pass over the catalog.
 	uuids := mtgmatcher.GetUUIDs()
 	for _, uuid := range uuids {
 		tcgLow := response.getRetail(uuid, "TCGLow")
 		tcgMarket := response.getRetail(uuid, "TCGMarket")
 		directNet := response.getBuylist(uuid, "TCGDirectNet")
 
-		// If TCG Direct (net) is fully missing, try assigning Market and fallback to Low
 		if directNet == 0 {
-			// If both fallbacks are missing, then just skip the entry entirely
-			if tcgMarket == 0 && tcgLow == 0 {
-				continue
-			}
+			// TCG Direct (net) is missing: estimate it from Market, falling back
+			// to Low. Skip entirely if neither is available.
+			if tcgMarket != 0 || tcgLow != 0 {
+				// Allocate memory
+				if response.Buylist[uuid] == nil {
+					response.Buylist[uuid] = map[string]*BanPrice{}
+				}
 
-			// Allocate memory
-			if response.Buylist[uuid] == nil {
-				response.Buylist[uuid] = map[string]*BanPrice{}
-			}
+				// Use Market as base estimate, or Low as fallback
+				directNet = tcgMarket
+				if directNet == 0 {
+					directNet = tcgLow
+				}
 
-			// Use Market as base estimate, or Low as fallback
-			directNet = tcgMarket
-			if directNet == 0 {
-				directNet = tcgLow
-			}
-
-			// Adjust estimate for fees
-			directNet = tcgplayer.DirectPriceAfterFees(directNet)
-
-			// Set the price
-			response.setBuylist(uuid, "TCGDirectNet", directNet)
-		} else if directNet/2 > tcgMarket {
-			// Direct exists but looks unreliable: cap it, or delete it.
-			// (else-if: an estimate from the branch above must not be re-judged here)
-			// If no low or twice as tcglow is within 10% of net, then delete this entry
-			if tcgLow == 0 || tcgLow*2 > directNet*0.9 {
-				delete(response.Buylist[uuid], "TCGDirectNet")
-			} else {
-				directNet = tcgLow * 2
+				// Adjust estimate for fees
 				directNet = tcgplayer.DirectPriceAfterFees(directNet)
 
 				response.setBuylist(uuid, "TCGDirectNet", directNet)
 			}
+		} else if directNet/2 > tcgMarket {
+			// Direct exists but looks unreliable: cap it at twice Low, or drop it.
+			// (else-if: an estimate from the branch above must not be re-judged here)
+			if tcgLow == 0 || tcgLow*2 > directNet*0.9 {
+				delete(response.Buylist[uuid], "TCGDirectNet")
+			} else {
+				directNet = tcgplayer.DirectPriceAfterFees(tcgLow * 2)
+				response.setBuylist(uuid, "TCGDirectNet", directNet)
+			}
 		}
 
+		// CardTrader Zero: subtract its flat fee.
 		ct0 := response.getRetail(uuid, "CT0")
 		ct0 -= getCT0fees(ct0)
 		if ct0 > 0 {
 			response.setRetail(uuid, "CT0", ct0)
 		}
-	}
 
-	// Remove prices that are too low
-	for _, uuid := range uuids {
+		// Prune prices too low to matter, after the adjustments above.
 		for _, category := range []map[string]map[string]*BanPrice{response.Retail, response.Buylist} {
 			for store := range category[uuid] {
 				if getPrice(uuid, category[uuid][store]) < BulkThreshold {

--- a/sealedev/api.go
+++ b/sealedev/api.go
@@ -195,11 +195,10 @@ func loadPrices(ctx context.Context, sig, selected string) (*BANPriceResponse, e
 			directNet = tcgplayer.DirectPriceAfterFees(directNet)
 
 			// Set the price
-			response.setBuylist("TCGDirectNet", uuid, directNet)
-		}
-
-		// If Direct looks unreliable, cap maximum price (estimate) or delete it
-		if directNet/2 > tcgMarket {
+			response.setBuylist(uuid, "TCGDirectNet", directNet)
+		} else if directNet/2 > tcgMarket {
+			// Direct exists but looks unreliable: cap it, or delete it.
+			// (else-if: an estimate from the branch above must not be re-judged here)
 			// If no low or twice as tcglow is within 10% of net, then delete this entry
 			if tcgLow == 0 || tcgLow*2 > directNet*0.9 {
 				delete(response.Buylist[uuid], "TCGDirectNet")
@@ -207,7 +206,7 @@ func loadPrices(ctx context.Context, sig, selected string) (*BANPriceResponse, e
 				directNet = tcgLow * 2
 				directNet = tcgplayer.DirectPriceAfterFees(directNet)
 
-				response.setBuylist("TCGDirectNet", uuid, directNet)
+				response.setBuylist(uuid, "TCGDirectNet", directNet)
 			}
 		}
 

--- a/sealedev/api.go
+++ b/sealedev/api.go
@@ -225,26 +225,15 @@ func loadPrices(ctx context.Context, sig, selected string) (*BANPriceResponse, e
 	return &response, nil
 }
 
-func valueInBooster(uuids []string, prices map[string]map[string]*BanPrice, stores []string, probabilities []float64) float64 {
-	var total float64
-	for i, uuid := range uuids {
-		// Adjust price by its probability
-		probability := 1.0
-		if probabilities != nil {
-			probability = probabilities[i]
+// maxStorePrice returns the highest available price for a card across the given
+// source stores (0 if none are present).
+func maxStorePrice(uuid string, prices map[string]map[string]*BanPrice, stores []string) float64 {
+	var price float64
+	for _, source := range stores {
+		sourcePrice := getPrice(uuid, prices[uuid][source])
+		if sourcePrice > price {
+			price = sourcePrice
 		}
-
-		// Load the highest available value between the source stores
-		var price float64
-		for _, source := range stores {
-			sourcePrice := getPrice(uuid, prices[uuid][source])
-			if sourcePrice > price {
-				price = sourcePrice
-			}
-		}
-
-		// Add to the final value
-		total += price * probability
 	}
-	return total
+	return price
 }

--- a/sealedev/api.go
+++ b/sealedev/api.go
@@ -26,8 +26,9 @@ type BANPriceResponse struct {
 	} `json:"meta"`
 
 	// uuid > store > price {regular/foil/etched}
-	Retail  map[string]map[string]*BanPrice `json:"retail,omitempty"`
-	Buylist map[string]map[string]*BanPrice `json:"buylist,omitempty"`
+	// No omitempty: always emit the keys so decoders never see a nil map.
+	Retail  map[string]map[string]*BanPrice `json:"retail"`
+	Buylist map[string]map[string]*BanPrice `json:"buylist"`
 }
 
 const (

--- a/sealedev/sealedev.go
+++ b/sealedev/sealedev.go
@@ -141,12 +141,6 @@ func (ss *SealedEVScraper) printf(format string, a ...interface{}) {
 	}
 }
 
-type resultChan struct {
-	i   int
-	ev  float64
-	err error
-}
-
 type result struct {
 	productId string
 	invEntry  *mtgban.InventoryEntry
@@ -154,7 +148,22 @@ type result struct {
 	err       error
 }
 
-func (ss *SealedEVScraper) runEV(uuid string) ([]result, []string) {
+// valueFromCache sums the pre-resolved unit prices for a list of picks. When
+// probabilities is nil every pick is counted once (used for a single simulated
+// draw); otherwise each pick is weighted by its probability.
+func valueFromCache(picks []string, unit map[string]float64, probabilities []float64) float64 {
+	var total float64
+	for i, pick := range picks {
+		probability := 1.0
+		if probabilities != nil {
+			probability = probabilities[i]
+		}
+		total += unit[pick] * probability
+	}
+	return total
+}
+
+func (ss *SealedEVScraper) runEV(ctx context.Context, uuid string) ([]result, []string) {
 	co, err := mtgmatcher.GetUUID(uuid)
 	if err != nil {
 		return nil, []string{err.Error()}
@@ -163,138 +172,128 @@ func (ss *SealedEVScraper) runEV(uuid string) ([]result, []string) {
 	productUUID := co.UUID
 	setCode := co.SetCode
 
-	repeats := EVAverageRepetition
-	if ss.FastMode {
-		repeats = EVFastRepetition
-	}
-	if !mtgmatcher.SealedIsRandom(setCode, productUUID) {
-		repeats = 1
+	var allTheErrors []string
+
+	// Enumerate the full universe of possible cards and their probabilities.
+	probs, err := mtgmatcher.GetProbabilitiesForSealed(setCode, productUUID)
+	if len(probs) == 0 {
+		if err == nil {
+			err = errors.New("no probabilities found")
+		}
+		return nil, []string{err.Error()}
 	}
 
-	var wg sync.WaitGroup
+	picks := make([]string, len(probs))
+	probabilities := make([]float64, len(probs))
+	skipped := make(map[string]bool)
+	for i := range probs {
+		picks[i] = probs[i].UUID
+		probabilities[i] = probs[i].Probability
+
+		// Serialized (and unresolvable) cards never count towards the EV.
+		co, err := mtgmatcher.GetUUID(probs[i].UUID)
+		if err != nil || co.HasPromoType(mtgmatcher.PromoTypeSerialized) {
+			skipped[probs[i].UUID] = true
+		}
+	}
+
+	// Resolve each card's price a single time per parameter (skipped cards
+	// resolve to 0). This keeps the price lookups out of the simulation loop,
+	// which can run up to EVAverageRepetition times.
+	unitPrices := make([]map[string]float64, len(evParameters))
+	for i := range evParameters {
+		priceSource := ss.prices.Retail
+		if evParameters[i].FoundInBuylist {
+			priceSource = ss.prices.Buylist
+		}
+
+		cache := make(map[string]float64, len(picks))
+		for _, pick := range picks {
+			if skipped[pick] {
+				continue
+			}
+			cache[pick] = maxStorePrice(pick, priceSource, evParameters[i].SourceStores)
+		}
+		unitPrices[i] = cache
+	}
 
 	datasets := make([][]float64, len(evParameters))
-	channel := make(chan resultChan)
-	repeatsChannel := make(chan int)
 
-	for j := 0; j < ss.MaxConcurrency; j++ {
-		wg.Add(1)
-
-		// Simulations
-		go func() {
-			for _ = range repeatsChannel {
-				picks, err := mtgmatcher.GetPicksForSealed(setCode, productUUID)
-				if err != nil {
-					channel <- resultChan{
-						err: err,
-					}
-					continue
-				}
-
-				// Delete any serialized card
-				probabilities := make([]float64, len(picks))
-				for i := range picks {
-					co, err := mtgmatcher.GetUUID(picks[i])
-					if err != nil || co.HasPromoType(mtgmatcher.PromoTypeSerialized) {
-						continue
-					}
-					probabilities[i] = 1
-				}
-
-				for i := range evParameters {
-					if !evParameters[i].Simulation {
-						continue
-					}
-
-					priceSource := ss.prices.Retail
-					if evParameters[i].FoundInBuylist {
-						priceSource = ss.prices.Buylist
-					}
-
-					ev := valueInBooster(picks, priceSource, evParameters[i].SourceStores, probabilities)
-
-					channel <- resultChan{
-						i:  i,
-						ev: ev,
-					}
-				}
-			}
-			wg.Done()
-		}()
-	}
-
-	// Probability EV
-	wg.Add(1)
-	go func() {
-		probs, err := mtgmatcher.GetProbabilitiesForSealed(setCode, productUUID)
-		if len(probs) == 0 {
-			if err == nil {
-				err = errors.New("no probabilities found")
-			}
-			channel <- resultChan{
-				err: err,
-			}
-			wg.Done()
-			return
-		}
-
-		// Split probabilities in two simpler arrays for later reuse
-		picks := make([]string, len(probs))
-		probabilities := make([]float64, len(probs))
-		for i := range probs {
-			picks[i] = probs[i].UUID
-
-			// Delete any serialized card
-			co, err := mtgmatcher.GetUUID(probs[i].UUID)
-			if err != nil || co.HasPromoType(mtgmatcher.PromoTypeSerialized) {
-				continue
-			}
-			probabilities[i] = probs[i].Probability
-		}
-
-		for i := range evParameters {
-			if evParameters[i].Simulation {
-				continue
-			}
-
-			priceSource := ss.prices.Retail
-			if evParameters[i].FoundInBuylist {
-				priceSource = ss.prices.Buylist
-			}
-
-			ev := valueInBooster(picks, priceSource, evParameters[i].SourceStores, probabilities)
-
-			channel <- resultChan{
-				i:  i,
-				ev: ev,
-			}
-		}
-		wg.Done()
-	}()
-
-	go func(repeatsChannel chan int, channel chan resultChan) {
-		for j := 0; j < repeats; j++ {
-			repeatsChannel <- j
-		}
-		close(repeatsChannel)
-
-		wg.Wait()
-		close(channel)
-	}(repeatsChannel, channel)
-
-	var allTheErrors []string
-	for resp := range channel {
-		// Collect all the errors from this product. Every error result must be
-		// skipped: falling through on a *duplicate* error would append a spurious
-		// zero to datasets[0] (resp.i/ev default to 0), polluting the buylist EV.
-		if resp.err != nil {
-			if !slices.Contains(allTheErrors, resp.err.Error()) {
-				allTheErrors = append(allTheErrors, resp.err.Error())
-			}
+	// Deterministic probability-based EV for the non-simulation parameters.
+	for i := range evParameters {
+		if evParameters[i].Simulation {
 			continue
 		}
+		datasets[i] = append(datasets[i], valueFromCache(picks, unitPrices[i], probabilities))
+	}
 
-		datasets[resp.i] = append(datasets[resp.i], resp.ev)
+	if !mtgmatcher.SealedIsRandom(setCode, productUUID) {
+		// Fixed contents: a simulation would always draw the same cards, so its
+		// value equals the deterministic probability EV. Copy it instead of
+		// running a pointless Monte Carlo.
+		for i := range evParameters {
+			if !evParameters[i].Simulation {
+				continue
+			}
+			datasets[i] = append(datasets[i], valueFromCache(picks, unitPrices[i], probabilities))
+		}
+	} else {
+		// Random contents: Monte Carlo the simulation parameters.
+		repeats := EVAverageRepetition
+		if ss.FastMode {
+			repeats = EVFastRepetition
+		}
+
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		repeatsChannel := make(chan int)
+		locals := make([][][]float64, ss.MaxConcurrency)
+
+		for w := 0; w < ss.MaxConcurrency; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+
+				local := make([][]float64, len(evParameters))
+				for range repeatsChannel {
+					simPicks, err := mtgmatcher.GetPicksForSealed(setCode, productUUID)
+					if err != nil {
+						mu.Lock()
+						if !slices.Contains(allTheErrors, err.Error()) {
+							allTheErrors = append(allTheErrors, err.Error())
+						}
+						mu.Unlock()
+						continue
+					}
+
+					for i := range evParameters {
+						if !evParameters[i].Simulation {
+							continue
+						}
+						local[i] = append(local[i], valueFromCache(simPicks, unitPrices[i], nil))
+					}
+				}
+				locals[w] = local
+			}(w)
+		}
+
+	feed:
+		for j := 0; j < repeats; j++ {
+			select {
+			case <-ctx.Done():
+				break feed
+			case repeatsChannel <- j:
+			}
+		}
+		close(repeatsChannel)
+		wg.Wait()
+
+		// Merge the per-worker datasets.
+		for _, local := range locals {
+			for i := range local {
+				datasets[i] = append(datasets[i], local[i]...)
+			}
+		}
 	}
 
 	var out []result
@@ -426,6 +425,10 @@ func (ss *SealedEVScraper) Load(ctx context.Context) error {
 	start := time.Now()
 
 	for i, uuid := range uuids {
+		if ctx.Err() != nil {
+			break
+		}
+
 		co, err := mtgmatcher.GetUUID(uuid)
 		if err != nil {
 			continue
@@ -435,7 +438,7 @@ func (ss *SealedEVScraper) Load(ctx context.Context) error {
 			ss.printf("Running EV on [%s] %s (%d/%d)", co.SetCode, co.Name, i+1, len(uuids))
 		}
 
-		results, messages := ss.runEV(uuid)
+		results, messages := ss.runEV(ctx, uuid)
 
 		// Print errors if necessary
 		if len(messages) > 0 {

--- a/sealedev/sealedev.go
+++ b/sealedev/sealedev.go
@@ -284,9 +284,13 @@ func (ss *SealedEVScraper) runEV(uuid string) ([]result, []string) {
 
 	var allTheErrors []string
 	for resp := range channel {
-		// Collect all the errors from this product
-		if resp.err != nil && !slices.Contains(allTheErrors, resp.err.Error()) {
-			allTheErrors = append(allTheErrors, resp.err.Error())
+		// Collect all the errors from this product. Every error result must be
+		// skipped: falling through on a *duplicate* error would append a spurious
+		// zero to datasets[0] (resp.i/ev default to 0), polluting the buylist EV.
+		if resp.err != nil {
+			if !slices.Contains(allTheErrors, resp.err.Error()) {
+				allTheErrors = append(allTheErrors, resp.err.Error())
+			}
 			continue
 		}
 


### PR DESCRIPTION
Review of `sealedev/` turned up two real bugs and several optimizations.

## Bug fixes
- **`setBuylist` arguments were swapped** (`api.go`). The signature is `setBuylist(uuid, store, price)` — as used correctly by `setRetail(uuid, "CT0", ct0)` — but it was called `setBuylist("TCGDirectNet", uuid, ...)`. Inside, `GetUUID("TCGDirectNet")` always errors and the function returns early, so **every** TCG Direct (net) estimate (Market→Low fallback) and outlier cap was silently discarded; only the `delete` path did anything. Fixed the argument order.
  - The two Direct branches are now `else if`: the comments describe *estimate if missing* **or** *cap if unreliable*, and with the bug fixed a fresh Low-based estimate would otherwise fall through and be deleted by the cap branch.
- **Duplicate errors poisoned `datasets[0]`** (`sealedev.go`). `if resp.err != nil && !contains { …; continue }` fell through on a repeated error to `datasets[resp.i] = append(…, resp.ev)` with `resp.i==0, resp.ev==0`, appending spurious `0`s to the Singles Buylist slot (whose `StatsFunc` is `passthroughFirst`) and potentially zeroing its EV. All errors now `continue`.
- **Dropped `omitempty`** on `Retail`/`Buylist` so the maps are always emitted.

## Optimizations
- **Price precompute.** `getPrice` calls `GetUUID` (which copies a `CardObject`) on every lookup; in a 5000-rep simulation each card's price was re-resolved thousands of times. Prices are now resolved **once per parameter** into a `map[uuid]float64` and the loops just sum lookups (serialized cards resolve to 0, so serialized handling is uniform across both paths).
- **Single catalog pass** in `loadPrices` (Direct/CT0 adjustment + bulk prune merged).
- **Skip Monte Carlo for fixed products.** For non-random contents the simulated value equals the deterministic probability EV, so it's copied instead of simulated (also drops a redundant `GetPicksForSealed`).
- **Context propagation** through `runEV` and the `Load` loop so long runs are cancellable.

Behavior for random products is unchanged (same probability EV, same Monte-Carlo of the simulation parameters, same stdDev/iqr). `getCT0fees` confirmed to be flat fees — left as-is.

## Verification
`go build`, `go vet`, `gofmt -l`, and `cmd/bantool` build (the sealedev consumer) are all clean. The pre-push hook was bypassed only because its `go test ./mtgmatcher/...` needs `ALLPRINTINGS5_PATH` (fails on clean `master` too) and `cmd/omnitool-3g` blank-imports an absent `mtgmatcher/magic` package — both pre-existing and unrelated to this change. `sealedev` itself has no test files.