### PR TITLE
abugames: Keep title collector numbers over stale card_number

### DIFF
--- a/abugames/preprocess.go
+++ b/abugames/preprocess.go
@@ -253,8 +253,11 @@ func preprocess(card *ABUCard) (*mtgmatcher.InputCard, error) {
 			variation = card.Number
 		} else {
 			// Check if variation contains a number as it's usually more
-			// accurate. If not, check the card.Number property (yolo)
-			num := mtgmatcher.ExtractNumber(variation)
+			// accurate. If not, check the card.Number property (yolo).
+			// ExtractNumericalValue (not the year-capped ExtractNumber) so a
+			// Secret Lair collector number >= 1993 (e.g. 7010) is recognized
+			// and not clobbered by a stale card.Number.
+			num := mtgmatcher.ExtractNumericalValue(variation)
 			if num == "" && card.Number != "" {
 				variation += " " + card.Number
 			}
@@ -333,7 +336,7 @@ func preprocess(card *ABUCard) (*mtgmatcher.InputCard, error) {
 	}
 
 	// Use collector number data when the variation carries has none, unless for a couple of editions
-	if card.Number != "" && mtgmatcher.ExtractNumber(variation) == "" {
+	if card.Number != "" && mtgmatcher.ExtractNumericalValue(variation) == "" {
 		switch edition {
 		case "Unfinity", "Promo":
 		default:

--- a/abugames/preprocess_test.go
+++ b/abugames/preprocess_test.go
@@ -1,0 +1,59 @@
+package abugames
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/mtgban/go-mtgban/mtgmatcher"
+)
+
+func TestMain(m *testing.M) {
+	path := os.Getenv("ALLPRINTINGS5_PATH")
+	if path == "" {
+		log.Fatalln("Need ALLPRINTINGS5_PATH variable set to run tests")
+	}
+	if err := mtgmatcher.LoadDatastoreFile(path); err != nil {
+		log.Fatalln(err)
+	}
+	os.Exit(m.Run())
+}
+
+// TestSecretLairNumberOverStaleCardNumber guards the case where ABU's
+// card_number disagrees with the collector number in the title. Secret Lair
+// numbers can be >= 1993, which the year-capped ExtractNumber can't see; a stale
+// card.Number ("1933") must not clobber the authoritative title number ("7010").
+func TestSecretLairNumberOverStaleCardNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		number  string // ABU card_number
+		wantSet string
+		wantNum string
+	}{
+		{"stale card_number", "1933", "SLD", "7010"},
+		{"matching card_number", "7010", "SLD", "7010"},
+		{"empty card_number", "", "SLD", "7010"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in, err := preprocess(&ABUCard{
+				DisplayTitle: "Counterspell (Secret Lair 7010) - FOIL",
+				Edition:      "Secret Lair Drop",
+				Number:       tt.number,
+				Language:     []string{"English"},
+			})
+			if err != nil {
+				t.Fatalf("preprocess: %v", err)
+			}
+			id, err := mtgmatcher.Match(in)
+			if err != nil {
+				t.Fatalf("match (variation %q): %v", in.Variation, err)
+			}
+			co, _ := mtgmatcher.GetUUID(id)
+			if co.SetCode != tt.wantSet || co.Number != tt.wantNum {
+				t.Errorf("got %s #%s, want %s #%s (variation %q)", co.SetCode, co.Number, tt.wantSet, tt.wantNum, in.Variation)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A Secret Lair listing can carry an ABU `card_number` that disagrees with the
collector number in its title. Example:
`Counterspell (Secret Lair 7010) - FOIL` arrives with `card_number = 1933` —
and SLD has Counterspell at **both** #1933 and #7010.

Both "does the variation already have a number?" checks in `preprocess` used the
year-capped `ExtractNumber`, which ignores any value ≥ 1993. So the `7010` in the
title was invisible, the code assumed no number was present, and appended the
stale `card_number` → variation `"Secret Lair 7010 1933"`. The matcher then
extracted `1933` (first value below 1993, skipping 7010) and resolved to
**SLD #1933★** instead of **#7010**.

## Fix

Use `mtgmatcher.ExtractNumericalValue` (first digit run, no year cap) for those
two checks, so any embedded collector number is recognized and an authoritative
title number isn't clobbered by a stale `card_number`. This also removes the need
to special-case the Secret Lair editions in the later append.

Adds `abugames/preprocess_test.go` (the package had no tests) covering the stale,
matching, and empty `card_number` cases — all now resolve to SLD #7010.

## Behavior note

Line ~336's generic append previously ignored numbers ≥ 1993 (treating release
years as "no number" so `card_number` would still be appended). It now counts any
digit run as a number for all editions. In practice year-tagged variations are
almost all promos, which the `Promo` case already excludes, so exposure is
minimal — but it is a small generalization beyond Secret Lair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)