### PR TITLE
abugames: Use a more generic function to extract card numbers

### DIFF
--- a/abugames/preprocess.go
+++ b/abugames/preprocess.go
@@ -254,10 +254,11 @@ func preprocess(card *ABUCard) (*mtgmatcher.InputCard, error) {
 		} else {
 			// Check if variation contains a number as it's usually more
 			// accurate. If not, check the card.Number property (yolo).
-			// ExtractNumericalValue (not the year-capped ExtractNumber) so a
-			// Secret Lair collector number >= 1993 (e.g. 7010) is recognized
-			// and not clobbered by a stale card.Number.
-			num := mtgmatcher.ExtractNumericalValue(variation)
+			// ExtractNumberAny (not the year-capped ExtractNumber) so a Secret
+			// Lair collector number >= 1993 (e.g. 7010) is recognized and not
+			// clobbered by a stale card.Number, while still ignoring dates and
+			// ordinals.
+			num := mtgmatcher.ExtractNumberAny(variation)
 			if num == "" && card.Number != "" {
 				variation += " " + card.Number
 			}
@@ -336,7 +337,7 @@ func preprocess(card *ABUCard) (*mtgmatcher.InputCard, error) {
 	}
 
 	// Use collector number data when the variation carries has none, unless for a couple of editions
-	if card.Number != "" && mtgmatcher.ExtractNumericalValue(variation) == "" {
+	if card.Number != "" && mtgmatcher.ExtractNumberAny(variation) == "" {
 		switch edition {
 		case "Unfinity", "Promo":
 		default:


### PR DESCRIPTION
Supersedes #40 (which used `ExtractNumericalValue`; this uses `ExtractNumberAny`).

## Summary

A Secret Lair listing can carry an ABU `card_number` that disagrees with the
collector number in its title. Example:
`Counterspell (Secret Lair 7010) - FOIL` arrives with `card_number = 1933` —
and SLD has Counterspell at **both** #1933 and #7010.

Both "does the variation already have a number?" checks in `preprocess` used the
year-capped `ExtractNumber`, which ignores any value ≥ 1993. So the `7010` in the
title was invisible, the code assumed no number was present, and appended the
stale `card_number` → variation `"Secret Lair 7010 1933"`. The matcher then
extracted `1933` (first value below 1993, skipping 7010) and resolved to
**SLD #1933★** instead of **#7010**.

## Fix

Use `mtgmatcher.ExtractNumberAny` for those two checks. It lifts only the 1993
year ceiling while keeping every other collector-number protection
`ExtractNumber` has — the month-name guard, ordinal guard (`10th Anniversary` →
`""`), M-prefix guard, and suffix handling. So a real ≥1993 collector number
(7010) is recognized without newly mistaking dates/ordinals for numbers.

Adds `abugames/preprocess_test.go` (the package had no tests) covering the stale,
matching, and empty `card_number` cases — all now resolve to SLD #7010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)