### PR TITLE
mtgmatcher: Rename ExtractNumericalValue to ExtractNumberValue

### DIFF
--- a/mtgmatcher/callbacks.go
+++ b/mtgmatcher/callbacks.go
@@ -919,7 +919,7 @@ func sldVariant(inCard *InputCard, card *Card) bool {
 		"Liliana's Contract",
 		"Kothophed, Soul Hoarder",
 		"Razaketh, the Foulblooded":
-		num, _ := strconv.Atoi(ExtractNumericalValue(card.Number))
+		num, _ := strconv.Atoi(ExtractNumberValue(card.Number))
 		if num < 200 {
 			result := strings.HasSuffix(card.Number, SuffixSpecial)
 			if inCard.isEtched() {
@@ -956,7 +956,7 @@ func sldVariant(inCard *InputCard, card *Card) bool {
 		"Mogis, God of Slaughter",
 		"Lava Dart", "Monastery Swiftspear", "Soul-Scar Mage", "Underworld Breach", "Mishra's Bauble",
 		"Chain Lightning", "Dragon's Rage Channeler", "Lava Spike", "Rift Bolt", "Skewer the Critics":
-		if !inCard.Contains(ExtractNumericalValue(card.Number)) {
+		if !inCard.Contains(ExtractNumberValue(card.Number)) {
 			return true
 		}
 	}

--- a/mtgmatcher/filter.go
+++ b/mtgmatcher/filter.go
@@ -1018,7 +1018,7 @@ func filterCards(inCard *InputCard, cardSet map[string][]Card) (outCards []Card)
 					filteredOutCards = append(filteredOutCards, card)
 				} else {
 					for probe, number := range multiPromosTable[set.Name][card.Name] {
-						if inCard.Contains(probe) && ExtractNumericalValue(card.Number) == number {
+						if inCard.Contains(probe) && ExtractNumberValue(card.Number) == number {
 							filteredOutCards = append(filteredOutCards, card)
 						}
 					}

--- a/mtgmatcher/mtgmatcher.go
+++ b/mtgmatcher/mtgmatcher.go
@@ -54,7 +54,7 @@ func MatchId(inputId string, finishes ...bool) (string, error) {
 			altCo := defaultBackend.UUIDs[variation]
 			// We assume that the collector number between the two version
 			// stays the same, with a different suffix
-			if ExtractNumericalValue(co.Number) == ExtractNumericalValue(altCo.Number) {
+			if ExtractNumberValue(co.Number) == ExtractNumberValue(altCo.Number) {
 				maybeId := output(altCo.Card, isFoil, isEtched)
 				altCo = defaultBackend.UUIDs[maybeId]
 

--- a/mtgmatcher/utils.go
+++ b/mtgmatcher/utils.go
@@ -226,7 +226,7 @@ func extractNumber(str string, threshold int) string {
 var reNumerical = regexp.MustCompile(`\d+`)
 
 // Obtain the numerical value of the input so that it can be used for strconv.Atoi()
-func ExtractNumericalValue(str string) string {
+func ExtractNumberValue(str string) string {
 	return strings.TrimLeft(reNumerical.FindString(str), "0")
 }
 

--- a/mtgmatcher/utils_test.go
+++ b/mtgmatcher/utils_test.go
@@ -262,12 +262,12 @@ var NumericTests = []ExtractTest{
 	},
 }
 
-func TestExtractNumericalValue(t *testing.T) {
+func TestExtractNumberValue(t *testing.T) {
 	for _, probe := range NumericTests {
 		test := probe
 		t.Run(test.In, func(t *testing.T) {
 			t.Parallel()
-			out := ExtractNumericalValue(test.In)
+			out := ExtractNumberValue(test.In)
 			if out != test.Out {
 				t.Errorf("FAIL %s: Expected '%s' got '%s'", test.In, test.Out, out)
 				return


### PR DESCRIPTION
Pure rename of the exported helper `ExtractNumericalValue` → `ExtractNumberValue`
and its call sites (`utils.go`, `mtgmatcher.go`, `filter.go`, `callbacks.go`) plus
the test. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)