### PR TITLE
mtgmatcher: fix SLC foil cards being reported as productless

### DIFF
--- a/mtgmatcher/backend.go
+++ b/mtgmatcher/backend.go
@@ -506,19 +506,6 @@ func (ap AllPrintings) Load() cardBackend {
 					card.PromoTypes = append(card.PromoTypes, "ruderiders")
 				}
 
-			// Upstream cannot properly represent foil cards
-			case "SLC":
-				if card.SourceProducts == nil {
-					card.SourceProducts = map[string][]string{}
-				}
-
-				num, _ := strconv.Atoi(card.Number)
-				if (num >= 1993 && num <= 2023) || (num >= 1 && num <= 26) {
-					card.SourceProducts["foil"] = card.SourceProducts["nonfoil"]
-				} else if num == 27 || num >= 28 && num <= 53 {
-					card.SourceProducts["foil"] = allCards[0].SourceProducts["nonfoil"]
-				}
-
 			case "SLD":
 				switch card.Number {
 				// One of the tokens is a DFC but burns a card number, skip it
@@ -672,6 +659,38 @@ func (ap AllPrintings) Load() cardBackend {
 					return sealedNames[filtered[i]] < sealedNames[filtered[j]]
 				})
 				card.SourceProducts[finish] = filtered
+			}
+
+			// Upstream cannot represent the foils of the Secret Lair Countdown
+			// drops: every card in them has only a chance to come in traditional
+			// foil, and a fractional chance to come in halo foil (which is a
+			// separate number entirely), so the products can only ever list the
+			// non-foil printings without distorting pull probabilities.
+			//
+			// Synthesize the missing foil sources from the non-foil ones. This has
+			// to happen *after* the filter above, which is finish-strict and would
+			// otherwise discard everything set here.
+			if set.Code == "SLC" {
+				if card.SourceProducts == nil {
+					card.SourceProducts = map[string][]string{}
+				}
+
+				// Never overwrite a source upstream already got right: the
+				// foil-only bonus cards (#27 and #2023) are declared as foil in
+				// their product and would be orphaned by a blind assignment.
+				if len(card.SourceProducts["foil"]) == 0 {
+					num, _ := strconv.Atoi(card.Number)
+					switch {
+					// Traditional foils share the product of their non-foil printing
+					case (num >= 1 && num <= 26) || (num >= 1993 && num <= 2022):
+						card.SourceProducts["foil"] = card.SourceProducts["nonfoil"]
+					// Halo foils have no non-foil printing of their own; they come
+					// from the same drop as the base cards (allCards[0] is #1, and
+					// its sources are already filtered by the time we get here).
+					case num >= 28 && num <= 53:
+						card.SourceProducts["foil"] = allCards[0].SourceProducts["nonfoil"]
+					}
+				}
 			}
 
 			// Custom properties for tokens


### PR DESCRIPTION
`s:SLC is:productless` returns **83 results** — every SLC foil printing except #27.

### Cause

The `case "SLC"` override synthesized `SourceProducts["foil"]` from the non-foil sources, but it ran early in the `for _, card := range allCards` loop — ~150 lines *before* the "filter out unneeded sources" pass, which re-validates every source through `isBaseSealed` → `contentsContainCard`. That check is **finish-strict**: for `finish == "foil"` a `card:` entry must have `item.Foil`, and deck entries must be foil there. The products list these cards as non-foil, so the filter discarded everything the override had just written.

**The override was effectively dead code.** #27 is the only survivor, and not because of the override — its product genuinely declares it as a foil `card:` entry, so it passes the filter on its own merits.

Separately, #2023 (Lotus Field) is a foil-only bonus card that upstream maps *correctly*, but the override blindly assigned it the card's own (empty) non-foil list, wiping the good source.

### Fix

- Move the synthesis to **after** the filter, so it survives.
- Only fill in a foil source when there isn't already one, so the foil-only bonus cards (#27, #2023) keep the correct source upstream provides.
- Drop `num == 27` from the halo-foil range — it needs no synthesis.

This can't be fixed in the data: every card has only a *chance* to come in traditional foil and a *fractional* chance to come in halo foil (a separate collector number), so the products can't declare them without distorting pull probabilities.

### Verification

Against `allprintings5.json`, counting SLC foil printings with no source:

| Block | before | after |
|---|---|---|
| #1–26 base | 26 | **0** |
| #27 bonus foil | 0 | **0** |
| #28–53 halo foil | 26 | **0** |
| #1993–2022 countdown | 30 | **0** |
| #2023 Lotus Field | 1 | **0** |
| **total** | **83** | **0** |

The before-column reproduces the live `is:productless` search exactly, block for block. `go build ./...`, `go vet`, and `go test ./mtgmatcher/` (with `ALLPRINTINGS5_PATH`) all pass.