### PR TITLE
Fix Secret Lair buylist matching: SLD year cap + CSI catalog notes

### DIFF
--- a/coolstuffinc/preprocess.go
+++ b/coolstuffinc/preprocess.go
@@ -507,6 +507,13 @@ func PreprocessBuylist(card CSIPriceEntry) (*mtgmatcher.InputCard, error) {
 
 		if num != "" {
 			variant = num + " " + cleanVar
+			// CSI's notes often just repeat the collector number followed by the
+			// product/deck name ("2406 - Goblin Storm Commander Deck"), which is
+			// noise that doubles the number and trips the variant/token filters.
+			// When the notes lead with the collector number, trust it alone.
+			if strings.HasPrefix(cleanVar, num) {
+				variant = num
+			}
 		}
 	case "Deckmasters":
 		variant = strings.TrimSpace(strings.Split(variant, "Deckmaster")[0])

--- a/mtgmatcher/filter.go
+++ b/mtgmatcher/filter.go
@@ -246,8 +246,11 @@ func filterPrintings(inCard *InputCard, editions []string) (printings []string) 
 				}
 
 				// Check that the card reported is not coming from a SLD Deck
-				// or if it does, make sure it is actually from SLD
-				if len(MatchInSetNumber(inCard.Name, "SLD", ExtractNumber(inCard.Variation))) == 0 && len(MatchInSet(inCard.Name, "PLST")) > 0 {
+				// or if it does, make sure it is actually from SLD. Use
+				// ExtractNumberAny so Secret Lair collector numbers above the
+				// year cap (e.g. 2406) aren't dropped and misrouted to PLST,
+				// mirroring the SLD number check further below.
+				if len(MatchInSetNumber(inCard.Name, "SLD", ExtractNumberAny(inCard.Variation))) == 0 && len(MatchInSet(inCard.Name, "PLST")) > 0 {
 					for _, name := range defaultBackend.SLDDeckNames {
 						deckNameInCard := Contains(inCard.Edition, name) || Contains(inCard.Variation, name)
 						if deckNameInCard {

--- a/mtgmatcher/matcher_test_data.json
+++ b/mtgmatcher/matcher_test_data.json
@@ -4941,5 +4941,15 @@
             "variant": "1993",
             "edition": "Secret Lair Drop"
         }
+    },
+    {
+        "uuid": "93e2d1fb-1976-5e3f-b30c-e76a061e081a",
+        "description": "sld_collector_number_above_year_cap_not_misrouted_to_plst",
+        "input": {
+            "name": "Zada, Hedron Grinder",
+            "variant": "2406 2406 Goblin Storm Commander Deck",
+            "edition": "Secret Lair",
+            "foil": true
+        }
     }
 ]


### PR DESCRIPTION
Two complementary fixes for Secret Lair cards resolving to the wrong printing (or not at all), surfaced by CoolStuffInc's buylist mapping `Zada, Hedron Grinder` to `PLST #A25-156` instead of `SLD #2406`.

## `mtgmatcher`: lift the year cap on the SLD/PLST router

The Secret Lair vs. The List check used `ExtractNumber`, which caps collector numbers at 1993. A Secret Lair card numbered above it (e.g. Zada #2406) produced no SLD match and, when a PLST printing existed, was **misrouted to The List**. Switched that one call to `ExtractNumberAny`, matching the SLD number check further down that already breaks the year cap for the same reason. Added a regression case (`sld_collector_number_above_year_cap_not_misrouted_to_plst`).

Cross-scraper: benefits any scraper feeding an SLD card with a number > 1993.

## `coolstuffinc`: trust the collector number for catalog-style SLD notes

CSI packs the product/deck name into the buylist `Notes` (`"2406 - Goblin Storm Commander Deck"`, `"... Oishii! Tokens"`). Appending it to the variation leaves stray words that collide with real card-name/variant tokens — `Tokens` trips the token matcher (`unsupported`), `Megatron` (the opponent in a Transformers product title) reads as a different card (`unknown variant`) — so those entries failed to match. When the notes lead with the collector number, use the number alone.

## Validation

- Full `mtgmatcher` suite green.
- Over the 2,952 CSI Secret Lair buylist entries: matched **2888 → 2904** (+16 recovered), PLST mis-route **1 → 0**, Zada resolves to `SLD #2406` foil.
- The two fixes address orthogonal failure modes (mis-route vs. total match failure) and don't overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)