### PR TITLE
tcgplayer: Disambiguate MagicFest promos by collector number

### DIFF
--- a/tcgplayer/preprocess.go
+++ b/tcgplayer/preprocess.go
@@ -536,6 +536,14 @@ func Preprocess(product *tcgplayer.Product, editions map[int]string) (*mtgmatche
 			variant = ""
 		}
 	case "MagicFest Cards":
+		// A card can be a MagicFest promo across several years (e.g. Counterspell
+		// is PF24 #1 and PF26 #5). Thread the collector number through so the
+		// matcher can tell them apart; the specific cases below still override it
+		// where the product name already carries a variant or the numbering
+		// differs from mtgjson's.
+		if variant == "" {
+			variant = number
+		}
 		switch cardName {
 		case "Lightning Bolt":
 			edition = "PF19"


### PR DESCRIPTION
`tcgid4scryfall` reported an aliasing error mapping product **540987** (`Counterspell [MagicFest Cards]`, `# 1`):

```
- Counterspell|PF24|1|nonfoil
- Counterspell|PF26|5|foil
```

### Cause

`Counterspell` is a MagicFest promo in two different years — `PF24 #1` and `PF26 #5` — but the "MagicFest Cards" TCGplayer group carries no year, only a collector number in the product's extended data. `Preprocess`'s `MagicFest Cards` case only threads that number for a hardcoded list of cards; `Counterspell` isn't on it, so it fell through with an **empty variation**. With no number, the matcher can't choose between the two years and aliases them.

The matcher itself is fine — given the number it resolves cleanly:

| Variation | Match |
|---|---|
| `"1"` | `PF24 #1` ✓ |
| `""` | **ALIAS** `[PF24#1] [PF26#5]` ✗ |
| `"5"` | `PF26 #5` |

(mtgjson already maps 540987 → PF24 #1, so no data was wrong; the tool just couldn't validate it — a coverage gap that recurs for any card printed in ≥2 MagicFest years.)

### Fix

Thread the collector number into the variation when the product name carries no variant of its own. The existing special cases still win — they either act on a non-empty parenthetical variant (Lightning Bolt "Future Sight", Arcane Signet) or reassign the number explicitly where TCGplayer's numbering differs from mtgjson's (the PF25 list).

### Verification

Through the real `Preprocess` + `Match`: `Counterspell [MagicFest Cards] # 1` → `Preprocess` yields `Variation="1"` → `Match` → `PF24 #1` (`tcgplayerProductId=540987`), no aliasing. `go build ./tcgplayer/` and the existing package test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)