### PR TITLE
sealedev: Add a Mana Pool EV entry

### DIFF
--- a/sealedev/sealedev.go
+++ b/sealedev/sealedev.go
@@ -119,6 +119,23 @@ var evParameters = []evConfig{
 		SourceStores: []string{"CT0"},
 		Simulation:   true,
 	},
+
+	// Mana Pool
+	{
+		Name:         "Mana Pool EV",
+		Shorthand:    "MPEV",
+		StatsFunc:    passthroughFirst,
+		SourceStores: []string{"MP"},
+	},
+	{
+		Name:      "Mana Pool Sim",
+		Shorthand: "MPSim",
+		StatsFunc: func(values []float64) (float64, error) {
+			return stats.Median(values)
+		},
+		SourceStores: []string{"MP"},
+		Simulation:   true,
+	},
 }
 
 type evOutputStash struct {


### PR DESCRIPTION
Adds Mana Pool as a sealed-EV source, mirroring the existing retail sources (TCG Low, CT Zero).

Mana Pool retail is already in the `all.json` price feed under store key **`MP`** (its scraper's `Info().Shorthand`), so no request change is needed — just two new `evParameters` entries, the standard EV/simulation pair:

- **Mana Pool EV** (`MPEV`) — deterministic probability EV from `MP` retail prices.
- **Mana Pool Sim** (`MPSim`) — Monte Carlo median.

Both are retail sources (`FoundInBuylist` false), so they emit inventory entries like TCG Low / CT Zero. `go build ./...` and `go vet ./sealedev/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)