### PR TITLE
starcitygames: Discard Duel Masters crossover promos

### DIFF
--- a/starcitygames/catalog.go
+++ b/starcitygames/catalog.go
@@ -135,6 +135,12 @@ func catalogHit(p CatalogProduct, foil bool) Hit {
 // alt-foil (surge/rainbow/cold) resolves to the plain foil. When the id is
 // missing or unresolved, it falls back to the SKU-driven preprocess path.
 func resolveProduct(game int, p CatalogProduct) (string, error) {
+	// Duel Masters crossover promos are catalogued under Magic but aren't Magic
+	// cards, so there's nothing to match; discard them.
+	if strings.Contains(p.Name, "(Duel Masters)") {
+		return "", mtgmatcher.ErrUnsupported
+	}
+
 	foil := catalogFoil(p)
 
 	switch game {


### PR DESCRIPTION
SCG catalogues Duel Masters crossover promos (e.g. `Living Death (Duel Masters)`, SKU `SGL-DM-PRM-…`) under `game: "Magic: The Gathering"`, but they aren't Magic cards and never resolve.

Discard any product whose name contains `(Duel Masters)` at the top of `resolveProduct` by returning `ErrUnsupported`, which `processProduct` already skips silently (no error spam in the logs).

`go build ./...` passes; verified a `(Duel Masters)` product returns `ErrUnsupported`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)