### PR TITLE
mtgmatcher: Record the collector number without its decorations

### DIFF
--- a/mtgmatcher/backend.go
+++ b/mtgmatcher/backend.go
@@ -701,6 +701,9 @@ func (ap AllPrintings) Load() cardBackend {
 			// Save the original uuid
 			card.Identifiers["mtgjsonId"] = card.UUID
 
+			// Save the collector number stripped of its ★/†/φ decorations
+			card.OriginalNumber = strings.TrimRight(card.Number, SuffixSpecial+SuffixVariant+SuffixPhiLow+"*")
+
 			// Now assign the card to the list of cards to be saved
 			filteredCards = append(filteredCards, card)
 

--- a/mtgmatcher/mtgjson.go
+++ b/mtgmatcher/mtgjson.go
@@ -155,6 +155,8 @@ type Card struct {
 		Type        string            `json:"type"`
 	} `json:"foreignData"`
 
+	OriginalNumber string
+
 	// A list of URLs containing the image of the card
 	// At a minimum "full" and "thumbnail" versions should be provided
 	Images map[string]string


### PR DESCRIPTION
Adds `Card.OriginalNumber` — the collector number with its `★`/`†`/`φ` (and `*`) decorations stripped — computed once at load via `strings.TrimRight`.

Set **before** the card is appended to `filteredCards` so it persists on the stored cards (the surrounding code copies cards by value into that slice, so a later assignment on the loop variable would be dropped).

Verified against `allprintings5.json`: `Form of the Dragon #187★` → `OriginalNumber="187"`, plain `#1` → `"1"`. `go build ./...` and the `mtgmatcher` suite pass.

Note: this strips only the star/dagger/phi decorations — letter suffixes (`123a`, `123p`) and prefixes (`A80`) are kept, unlike the digits-only `ExtractNumberValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)