### PR TITLE
coolstuffinc: Retry the buylist fetch on truncated downloads

### DIFF
--- a/coolstuffinc/api.go
+++ b/coolstuffinc/api.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/hashicorp/go-cleanhttp"
@@ -103,6 +104,24 @@ type CSIPriceEntry struct {
 
 func GetBuylist(ctx context.Context, game string) ([]CSIPriceEntry, error) {
 	link := fmt.Sprintf(csiBuylistURL, game)
+
+	// The sell list is a large uncompressed download that occasionally
+	// truncates mid-stream (unexpected EOF), so retry the whole fetch.
+	const attempts = 3
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		var entries []CSIPriceEntry
+		entries, err = fetchBuylist(ctx, link)
+		if err == nil {
+			return entries, nil
+		}
+		time.Sleep(time.Duration(attempt) * time.Second)
+	}
+
+	return nil, err
+}
+
+func fetchBuylist(ctx context.Context, link string) ([]CSIPriceEntry, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, link, http.NoBody)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

`coolstuffinc_sealed` intermittently fails CI with:

```
- buylist load failed: unexpected EOF
- vendor CSISealed has no data
```

(example: [run 30872330069](https://github.com/mtgban/go-mtgban/actions/runs/30872330069/job/91876712960))

The sell list is served as a single **~42 MB uncompressed** JSON
(`GeneratedFiles/SellList/Section-mtg.json` — the server ignores gzip and
always returns the raw body). `GetBuylist` streams it straight into
`json.Decode` with a plain client and **no retry**. On a flaky CI network the
long transfer occasionally truncates mid-stream, the decode returns
`unexpected EOF`, and the whole load is lost.

`GetBuylist` is shared by both CSI scrapers. The singles scraper also loads
retail inventory, so a buylist EOF there only loses part of the data — but the
**sealed** scraper's only vendor data is the buylist, so one truncation leaves
it empty and bantool exits 2, failing the run.

## Change

Split the request+decode into `fetchBuylist` and retry the whole fetch up to 3
times with a short linear backoff. A truncated download simply triggers another
attempt. Minimal on purpose — no Content-Length validation or client swap for
now. Both the singles and sealed scrapers benefit.